### PR TITLE
Add autocxx support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chirp"
 version = "0.1.0"
 dependencies = [
+ "autocxx",
+ "autocxx-build",
  "chirp-sys",
+ "cmake",
+ "cxx",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,9 @@ edition = "2021"
 
 [dependencies]
 chirp-sys = { path = "chirp-sys" }
+autocxx = "0.27.0"
+cxx = "1.0.124"
+
+[build-dependencies]
+cmake = "0.1.50"
+autocxx-build = "0.27.0"

--- a/chirp-sys/Cargo.toml
+++ b/chirp-sys/Cargo.toml
@@ -10,3 +10,6 @@ cxx = "1.0.124"
 [build-dependencies]
 cmake = "0.1.50"
 autocxx-build = "0.27.0"
+
+[build]
+script = "lib.rs"

--- a/chirp-sys/build.rs
+++ b/chirp-sys/build.rs
@@ -9,7 +9,6 @@ fn main() {
         .define("USE_LLD", "off")
         .define("USE_MOLD", "on")
         .build();
-    
 
     println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib=static=taichi_core");
@@ -18,8 +17,11 @@ fn main() {
     println!("cargo:rustc-link-lib=static=ti_device_api");
 
     let include = dst.join("include");
-    let mut cc = autocxx_build::Builder::new("src/lib.rs", [&include]).build().unwrap();
+    let mut cc = autocxx_build::Builder::new("src/lib.rs", [&include])
+        .extra_clang_args(&["-std=c++17", "-DTI_INCLUDED=true"])
+        .build()
+        .unwrap();
     cc.define("TI_INCLUDED", "true")
-        .include(include)
+        .flag_if_supported("-std=c++17")
         .compile("chirpy");
 }

--- a/chirp-sys/src/lib.rs
+++ b/chirp-sys/src/lib.rs
@@ -1,4 +1,16 @@
+use autocxx::prelude::*;
 
+pub mod ir_builder {
+    autocxx::include_cpp! {
+        #include "taichi/ir/ir_builder.h"
+        // #include "taichi/ir/type.h"
+        // #include "taichi/ir/ir.h"
+        name!(ffi)
+        safety!(unsafe_ffi)
+        generate!("taichi::lang::IRBuilder")
+    }
+    pub use ffi::*;
+}
 
 #[cxx::bridge(namespace = "taichi::lang")]
 pub mod bridge {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,14 @@
 // temp for testing
-
+use autocxx::prelude::*;
 fn main() {
     chirp_sys::bridge::ir_builder_new();
+    //C++ Heap: within_unique_ptr()
+    //Rust Heap: within_box()
+    //Rust Stack: just new()
+    let mut builder = chirp_sys::ir_builder::taichi::lang::IRBuilder::new().within_box();
+    // let mut sum = builder.as_mut().create_local_var();
+    // let mut sum_ptr = &sum;
+    // unsafe {
+    //     builder.as_mut().create_local_store(*sum_ptr, builder.as_mut().get_float32(0.2));
+    // }
 }


### PR DESCRIPTION
Add `autocxx` in chirp/Cargo.toml because of the trait scope.
For now it only generates bindings for `taichi::lang::IRBuilder`.